### PR TITLE
Update PacketRegister.cpp

### DIFF
--- a/DCCpp_Uno/src/PacketRegister.cpp
+++ b/DCCpp_Uno/src/PacketRegister.cpp
@@ -234,9 +234,8 @@ void RegisterList::readCV(const char *s) volatile{
       if(c>ACK_SAMPLE_THRESHOLD) {
         d=1;
       }
-  loadPacket(0,resetPacket,2,1);           // Final reset packet completed (and decoder begins to respond)
     }
-
+ loadPacket(0,resetPacket,2,1);           // Final reset packet completed (and decoder begins to respond)
     bitWrite(bValue,i,d);
   }
 

--- a/DCCpp_Uno/src/PacketRegister.cpp
+++ b/DCCpp_Uno/src/PacketRegister.cpp
@@ -227,7 +227,7 @@ void RegisterList::readCV(const char *s) volatile{
 
     loadPacket(0,resetPacket,2,3);          // NMRA recommends starting with 3 reset packets
     loadPacket(0,bRead,3,5);                // NMRA recommends 5 verfy packets
-    loadPacket(0,resetPacket,2,1);          // forces code to wait until all repeats of bRead are completed (and decoder begins to respond)
+    loadPacket(0,bRead,3,1);          // forces code to wait until all repeats of bRead are completed (and decoder begins to respond)
 
     for(int j=0;j<ACK_SAMPLE_COUNT;j++){
       c=(analogRead(CURRENT_MONITOR_PIN_PROG)-base)*ACK_SAMPLE_SMOOTHING+c*(1.0-ACK_SAMPLE_SMOOTHING);
@@ -253,7 +253,7 @@ void RegisterList::readCV(const char *s) volatile{
 
   loadPacket(0,resetPacket,2,3);          // NMRA recommends starting with 3 reset packets
   loadPacket(0,bRead,3,5);                // NMRA recommends 5 verfy packets
-  loadPacket(0,resetPacket,2,1);          // forces code to wait until all repeats of bRead are completed (and decoder begins to respond)
+  loadPacket(0,bRead,3,1);          // forces code to wait until all repeats of bRead are completed (and decoder begins to respond)
 
   for(int j=0;j<ACK_SAMPLE_COUNT;j++){
     c=(analogRead(CURRENT_MONITOR_PIN_PROG)-base)*ACK_SAMPLE_SMOOTHING+c*(1.0-ACK_SAMPLE_SMOOTHING);
@@ -300,7 +300,7 @@ void RegisterList::writeCVByte(const char *s) volatile{
 
   loadPacket(0,resetPacket,2,3);          // NMRA recommends starting with 3 reset packets
   loadPacket(0,bWrite,3,5);               // NMRA recommends 5 verfy packets
-  loadPacket(0,resetPacket,2,1);          // forces code to wait until all repeats of bRead are completed (and decoder begins to respond)
+  loadPacket(0,bWrite,3,1);          // forces code to wait until all repeats of bRead are completed (and decoder begins to respond)
 
   for(int j=0;j<ACK_SAMPLE_COUNT;j++){
     c=(analogRead(CURRENT_MONITOR_PIN_PROG)-base)*ACK_SAMPLE_SMOOTHING+c*(1.0-ACK_SAMPLE_SMOOTHING);
@@ -349,7 +349,7 @@ void RegisterList::writeCVBit(const char *s) volatile{
 
   loadPacket(0,resetPacket,2,3);          // NMRA recommends starting with 3 reset packets
   loadPacket(0,bWrite,3,5);               // NMRA recommends 5 verfy packets
-  loadPacket(0,resetPacket,2,1);          // forces code to wait until all repeats of bRead are completed (and decoder begins to respond)
+  loadPacket(0,bWrite,3,1);          // forces code to wait until all repeats of bRead are completed (and decoder begins to respond)
 
   for(int j=0;j<ACK_SAMPLE_COUNT;j++){
     c=(analogRead(CURRENT_MONITOR_PIN_PROG)-base)*ACK_SAMPLE_SMOOTHING+c*(1.0-ACK_SAMPLE_SMOOTHING);

--- a/DCCpp_Uno/src/PacketRegister.cpp
+++ b/DCCpp_Uno/src/PacketRegister.cpp
@@ -225,9 +225,10 @@ void RegisterList::readCV(const char *s) volatile{
 
     bRead[2]=0xE8+i;
 
-    loadPacket(0,resetPacket,2,3);          // NMRA recommends starting with 3 reset packets
-    loadPacket(0,bRead,3,5);                // NMRA recommends 5 verfy packets
-    loadPacket(0,bRead,3,1);          // forces code to wait until all repeats of bRead are completed (and decoder begins to respond)
+loadPacket(0,resetPacket,2,3); // NMRA recommends starting with 3 reset packets
+loadPacket(0,bRead,3,5); // NMRA recommends 5 verify packets
+loadPacket(0,bRead,3,6); // NMRA recommends 6 write or reset packets for decoder recovery time
+loadPacket(0,resetPacket,2,1); // Final reset packet completed (and decoder begins to respond)
 
     for(int j=0;j<ACK_SAMPLE_COUNT;j++){
       c=(analogRead(CURRENT_MONITOR_PIN_PROG)-base)*ACK_SAMPLE_SMOOTHING+c*(1.0-ACK_SAMPLE_SMOOTHING);
@@ -251,9 +252,10 @@ void RegisterList::readCV(const char *s) volatile{
   bRead[0]=0x74+(highByte(cv)&0x03);   // set-up to re-verify entire byte
   bRead[2]=bValue;
 
-  loadPacket(0,resetPacket,2,3);          // NMRA recommends starting with 3 reset packets
-  loadPacket(0,bRead,3,5);                // NMRA recommends 5 verfy packets
-  loadPacket(0,bRead,3,1);          // forces code to wait until all repeats of bRead are completed (and decoder begins to respond)
+  loadPacket(0,resetPacket,2,3); // NMRA recommends starting with 3 reset packets
+  loadPacket(0,bRead,3,5); // NMRA recommends 5 verify packets
+  loadPacket(0,bRead,3,6); // NMRA recommends 6 write or reset packets for decoder recovery time
+  loadPacket(0,resetPacket,2,1); // Final reset packet completed (and decoder begins to respond)
 
   for(int j=0;j<ACK_SAMPLE_COUNT;j++){
     c=(analogRead(CURRENT_MONITOR_PIN_PROG)-base)*ACK_SAMPLE_SMOOTHING+c*(1.0-ACK_SAMPLE_SMOOTHING);
@@ -283,9 +285,11 @@ void RegisterList::writeCVByte(const char *s) volatile{
   bWrite[1]=lowByte(cv);
   bWrite[2]=bValue;
 
-  loadPacket(0,resetPacket,2,1);
-  loadPacket(0,bWrite,3,4);
-  loadPacket(0,resetPacket,2,1);
+ 
+  loadPacket(0,resetPacket,2,3); // NMRA recommends starting with 3 reset packets
+  loadPacket(0,bWrite,3,5); // NMRA recommends 5 verify packets
+  loadPacket(0,bWtite,3,6); // NMRA recommends 6 write or reset packets for decoder recovery time
+  loadPacket(0,resetPacket,2,1); // Final reset packet completed (and decoder begins to respond)
   loadPacket(0,idlePacket,2,10);
 
   c=0;
@@ -298,9 +302,10 @@ void RegisterList::writeCVByte(const char *s) volatile{
 
   bWrite[0]=0x74+(highByte(cv)&0x03);   // set-up to re-verify entire byte
 
-  loadPacket(0,resetPacket,2,3);          // NMRA recommends starting with 3 reset packets
-  loadPacket(0,bWrite,3,5);               // NMRA recommends 5 verfy packets
-  loadPacket(0,bWrite,3,1);          // forces code to wait until all repeats of bRead are completed (and decoder begins to respond)
+  loadPacket(0,resetPacket,2,3); // NMRA recommends starting with 3 reset packets
+  loadPacket(0,bWrite,3,5); // NMRA recommends 5 verify packets
+  loadPacket(0,bWtite,3,6); // NMRA recommends 6 write or reset packets for decoder recovery time
+  loadPacket(0,resetPacket,2,1); // Final reset packet (and decoder begins to respond)
 
   for(int j=0;j<ACK_SAMPLE_COUNT;j++){
     c=(analogRead(CURRENT_MONITOR_PIN_PROG)-base)*ACK_SAMPLE_SMOOTHING+c*(1.0-ACK_SAMPLE_SMOOTHING);
@@ -332,11 +337,12 @@ void RegisterList::writeCVBit(const char *s) volatile{
   bWrite[1]=lowByte(cv);
   bWrite[2]=0xF0+bValue*8+bNum;
 
-  loadPacket(0,resetPacket,2,1);
-  loadPacket(0,bWrite,3,4);
-  loadPacket(0,resetPacket,2,1);
+  loadPacket(0,resetPacket,2,3); // NMRA recommends starting with 3 reset packets
+  loadPacket(0,bWrite,3,5); // NMRA recommends 5 verify packets
+  loadPacket(0,bWtite,3,6); // NMRA recommends 6 write or reset packets for decoder recovery time
+  loadPacket(0,resetPacket,2,1); // Final reset packet completed (and decoder begins to respond)
   loadPacket(0,idlePacket,2,10);
-
+  
   c=0;
   d=0;
   base=0;
@@ -347,10 +353,12 @@ void RegisterList::writeCVBit(const char *s) volatile{
 
   bitClear(bWrite[2],4);              // change instruction code from Write Bit to Verify Bit
 
-  loadPacket(0,resetPacket,2,3);          // NMRA recommends starting with 3 reset packets
-  loadPacket(0,bWrite,3,5);               // NMRA recommends 5 verfy packets
-  loadPacket(0,bWrite,3,1);          // forces code to wait until all repeats of bRead are completed (and decoder begins to respond)
-
+  loadPacket(0,resetPacket,2,3); // NMRA recommends starting with 3 reset packets
+  loadPacket(0,bWrite,3,5); // NMRA recommends 5 verify packets
+  loadPacket(0,bWtite,3,6); // NMRA recommends 6 write or reset packets for decoder recovery time
+  loadPacket(0,resetPacket,2,1); // Final reset packetcompleted (and decoder begins to respond)
+  loadPacket(0,idlePacket,2,10);
+  
   for(int j=0;j<ACK_SAMPLE_COUNT;j++){
     c=(analogRead(CURRENT_MONITOR_PIN_PROG)-base)*ACK_SAMPLE_SMOOTHING+c*(1.0-ACK_SAMPLE_SMOOTHING);
     if(c>ACK_SAMPLE_THRESHOLD)

--- a/DCCpp_Uno/src/PacketRegister.cpp
+++ b/DCCpp_Uno/src/PacketRegister.cpp
@@ -207,9 +207,9 @@ void RegisterList::readCV(const char *s) volatile{
   if(sscanf(s,"%d %d %d",&cv,&callBack,&callBackSub) != 3) {         // cv = 1-1024
     return;
   }
-  cv--;                              // actual CV addresses are cv-1 (0-1023)
+  cv--;                                    // actual CV addresses are cv-1 (0-1023)
 
-  bRead[0]=0x78+(highByte(cv)&0x03);   // any CV>1023 will become modulus(1024) due to bit-mask of 0x03
+  bRead[0]=0x78+(highByte(cv)&0x03);       // any CV>1023 will become modulus(1024) due to bit-mask of 0x03
   bRead[1]=lowByte(cv);
 
   bValue=0;
@@ -225,16 +225,16 @@ void RegisterList::readCV(const char *s) volatile{
 
     bRead[2]=0xE8+i;
 
-loadPacket(0,resetPacket,2,3); // NMRA recommends starting with 3 reset packets
-loadPacket(0,bRead,3,5); // NMRA recommends 5 verify packets
-loadPacket(0,bRead,3,6); // NMRA recommends 6 write or reset packets for decoder recovery time
-loadPacket(0,resetPacket,2,1); // Final reset packet completed (and decoder begins to respond)
+loadPacket(0,resetPacket,2,3);            // NMRA recommends starting with 3 reset packets
+loadPacket(0,bRead,3,5);                  // NMRA recommends 5 verify packets
+loadPacket(0, idlePacket, 2, 6);          // NMRA recommends 6 idle or reset packets for decoder recovery time
 
     for(int j=0;j<ACK_SAMPLE_COUNT;j++){
       c=(analogRead(CURRENT_MONITOR_PIN_PROG)-base)*ACK_SAMPLE_SMOOTHING+c*(1.0-ACK_SAMPLE_SMOOTHING);
       if(c>ACK_SAMPLE_THRESHOLD) {
         d=1;
       }
+ loadPacket(0,resetPacket,2,1);           // Final reset packet completed (and decoder begins to respond)
     }
 
     bitWrite(bValue,i,d);
@@ -249,20 +249,21 @@ loadPacket(0,resetPacket,2,1); // Final reset packet completed (and decoder begi
   }
   base/=ACK_BASE_COUNT;
 
-  bRead[0]=0x74+(highByte(cv)&0x03);   // set-up to re-verify entire byte
+  bRead[0]=0x74+(highByte(cv)&0x03);     // set-up to re-verify entire byte
   bRead[2]=bValue;
 
-  loadPacket(0,resetPacket,2,3); // NMRA recommends starting with 3 reset packets
-  loadPacket(0,bRead,3,5); // NMRA recommends 5 verify packets
-  loadPacket(0,bRead,3,6); // NMRA recommends 6 write or reset packets for decoder recovery time
-  loadPacket(0,resetPacket,2,1); // Final reset packet completed (and decoder begins to respond)
-
+  loadPacket(0,resetPacket,2,3);        // NMRA recommends starting with 3 reset packets
+  loadPacket(0,bRead,3,5);              // NMRA recommends 5 verify packets
+  loadPacket(0, idlePacket, 2, 6);      // NMRA recommends 6 idle or reset packets for decoder recovery time
+  
   for(int j=0;j<ACK_SAMPLE_COUNT;j++){
     c=(analogRead(CURRENT_MONITOR_PIN_PROG)-base)*ACK_SAMPLE_SMOOTHING+c*(1.0-ACK_SAMPLE_SMOOTHING);
     if(c>ACK_SAMPLE_THRESHOLD)
       d=1;
   }
-
+  
+  loadPacket(0,resetPacket,2,1);        // Final reset packet completed (and decoder begins to respond)
+  
   if(d==0)    // verify unsuccessful
     bValue=-1;
 
@@ -279,19 +280,17 @@ void RegisterList::writeCVByte(const char *s) volatile{
 
   if(sscanf(s,"%d %d %d %d",&cv,&bValue,&callBack,&callBackSub)!=4)          // cv = 1-1024
     return;
-  cv--;                              // actual CV addresses are cv-1 (0-1023)
+  cv--;                                  // actual CV addresses are cv-1 (0-1023)
 
   bWrite[0]=0x7C+(highByte(cv)&0x03);   // any CV>1023 will become modulus(1024) due to bit-mask of 0x03
   bWrite[1]=lowByte(cv);
   bWrite[2]=bValue;
 
  
-  loadPacket(0,resetPacket,2,3); // NMRA recommends starting with 3 reset packets
-  loadPacket(0,bWrite,3,5); // NMRA recommends 5 verify packets
-  loadPacket(0,bWtite,3,6); // NMRA recommends 6 write or reset packets for decoder recovery time
-  loadPacket(0,resetPacket,2,1); // Final reset packet completed (and decoder begins to respond)
-  loadPacket(0,idlePacket,2,10);
-
+  loadPacket(0,resetPacket,2,3);        // NMRA recommends starting with 3 reset packets
+  loadPacket(0,bWrite,3,5);             // NMRA recommends 5 verify packets
+  loadPacket(0,bWtite,3,6);             // NMRA recommends 6 write or reset packets for decoder recovery time
+    
   c=0;
   d=0;
   base=0;
@@ -299,20 +298,23 @@ void RegisterList::writeCVByte(const char *s) volatile{
   for(int j=0;j<ACK_BASE_COUNT;j++)
     base+=analogRead(CURRENT_MONITOR_PIN_PROG);
   base/=ACK_BASE_COUNT;
+  
+  loadPacket(0,resetPacket,2,1); // Final reset packet completed (and decoder begins to respond)
 
-  bWrite[0]=0x74+(highByte(cv)&0x03);   // set-up to re-verify entire byte
+  bWrite[0]=0x74+(highByte(cv)&0x03);    // set-up to re-verify entire byte
 
-  loadPacket(0,resetPacket,2,3); // NMRA recommends starting with 3 reset packets
-  loadPacket(0,bWrite,3,5); // NMRA recommends 5 verify packets
-  loadPacket(0,bWtite,3,6); // NMRA recommends 6 write or reset packets for decoder recovery time
-  loadPacket(0,resetPacket,2,1); // Final reset packet (and decoder begins to respond)
-
+  loadPacket(0,resetPacket,2,3);        // NMRA recommends starting with 3 reset packets
+  loadPacket(0,bWrite,3,5);             // NMRA recommends 5 verify packets
+  loadPacket(0,bWtite,3,6);             // NMRA recommends 6 write or reset packets for decoder recovery time
+  
   for(int j=0;j<ACK_SAMPLE_COUNT;j++){
     c=(analogRead(CURRENT_MONITOR_PIN_PROG)-base)*ACK_SAMPLE_SMOOTHING+c*(1.0-ACK_SAMPLE_SMOOTHING);
     if(c>ACK_SAMPLE_THRESHOLD)
       d=1;
   }
-
+  
+  loadPacket(0,resetPacket,2,1);        // Final reset packet (and decoder begins to respond)
+  
   if(d==0)    // verify unsuccessful
     bValue=-1;
 
@@ -329,20 +331,17 @@ void RegisterList::writeCVBit(const char *s) volatile{
 
   if(sscanf(s,"%d %d %d %d %d",&cv,&bNum,&bValue,&callBack,&callBackSub)!=5)          // cv = 1-1024
     return;
-  cv--;                              // actual CV addresses are cv-1 (0-1023)
+  cv--;                                 // actual CV addresses are cv-1 (0-1023)
   bValue=bValue%2;
   bNum=bNum%8;
 
   bWrite[0]=0x78+(highByte(cv)&0x03);   // any CV>1023 will become modulus(1024) due to bit-mask of 0x03
   bWrite[1]=lowByte(cv);
   bWrite[2]=0xF0+bValue*8+bNum;
-
-  loadPacket(0,resetPacket,2,3); // NMRA recommends starting with 3 reset packets
-  loadPacket(0,bWrite,3,5); // NMRA recommends 5 verify packets
-  loadPacket(0,bWtite,3,6); // NMRA recommends 6 write or reset packets for decoder recovery time
-  loadPacket(0,resetPacket,2,1); // Final reset packet completed (and decoder begins to respond)
-  loadPacket(0,idlePacket,2,10);
-  
+  loadPacket(0,resetPacket,2,3);        // NMRA recommends starting with 3 reset packets
+  loadPacket(0,bWrite,3,5);             // NMRA recommends 5 verify packets
+  loadPacket(0,bWtite,3,6);             // NMRA recommends 6 write or reset packets for decoder recovery time
+      
   c=0;
   d=0;
   base=0;
@@ -350,20 +349,21 @@ void RegisterList::writeCVBit(const char *s) volatile{
   for(int j=0;j<ACK_BASE_COUNT;j++)
     base+=analogRead(CURRENT_MONITOR_PIN_PROG);
   base/=ACK_BASE_COUNT;
+  
+  loadPacket(0,resetPacket,2,1);      // Final reset packet completed (and decoder begins to respond)
 
   bitClear(bWrite[2],4);              // change instruction code from Write Bit to Verify Bit
-
-  loadPacket(0,resetPacket,2,3); // NMRA recommends starting with 3 reset packets
-  loadPacket(0,bWrite,3,5); // NMRA recommends 5 verify packets
-  loadPacket(0,bWtite,3,6); // NMRA recommends 6 write or reset packets for decoder recovery time
-  loadPacket(0,resetPacket,2,1); // Final reset packetcompleted (and decoder begins to respond)
-  loadPacket(0,idlePacket,2,10);
-  
+  loadPacket(0,resetPacket,2,3);      // NMRA recommends starting with 3 reset packets
+  loadPacket(0,bWrite,3,5);           // NMRA recommends 5 verify packets
+  loadPacket(0,bWtite,3,6);           // NMRA recommends 6 write or reset packets for decoder recovery time
+    
   for(int j=0;j<ACK_SAMPLE_COUNT;j++){
     c=(analogRead(CURRENT_MONITOR_PIN_PROG)-base)*ACK_SAMPLE_SMOOTHING+c*(1.0-ACK_SAMPLE_SMOOTHING);
     if(c>ACK_SAMPLE_THRESHOLD)
       d=1;
   }
+  
+  loadPacket(0,resetPacket,2,1);      // Final reset packetcompleted (and decoder begins to respond)
 
   if(d==0)    // verify unsuccessful
     bValue=-1;

--- a/DCCpp_Uno/src/PacketRegister.cpp
+++ b/DCCpp_Uno/src/PacketRegister.cpp
@@ -287,7 +287,7 @@ void RegisterList::writeCVByte(const char *s) volatile{
  
   loadPacket(0,resetPacket,2,3);        // NMRA recommends starting with 3 reset packets
   loadPacket(0,bWrite,3,5);             // NMRA recommends 5 verify packets
-  loadPacket(0,bWtite,3,6);             // NMRA recommends 6 write or reset packets for decoder recovery time
+  loadPacket(0,bWrite,3,6);             // NMRA recommends 6 write or reset packets for decoder recovery time
     
   c=0;
   d=0;
@@ -297,11 +297,11 @@ void RegisterList::writeCVByte(const char *s) volatile{
     base+=analogRead(CURRENT_MONITOR_PIN_PROG);
   base/=ACK_BASE_COUNT;
   
-  bWrite[0]=0x74+(highByte(cv)&0x03);    // set-up to re-verify entire byte
+  bWrite[0]=0x74+(highByte(cv)&0x03);   // set-up to re-verify entire byte
 
   loadPacket(0,resetPacket,2,3);        // NMRA recommends starting with 3 reset packets
   loadPacket(0,bWrite,3,5);             // NMRA recommends 5 verify packets
-  loadPacket(0,bWtite,3,6);             // NMRA recommends 6 write or reset packets for decoder recovery time
+  loadPacket(0,bWrite,3,6);             // NMRA recommends 6 write or reset packets for decoder recovery time
   
   for(int j=0;j<ACK_SAMPLE_COUNT;j++){
     c=(analogRead(CURRENT_MONITOR_PIN_PROG)-base)*ACK_SAMPLE_SMOOTHING+c*(1.0-ACK_SAMPLE_SMOOTHING);
@@ -336,7 +336,7 @@ void RegisterList::writeCVBit(const char *s) volatile{
   bWrite[2]=0xF0+bValue*8+bNum;
   loadPacket(0,resetPacket,2,3);        // NMRA recommends starting with 3 reset packets
   loadPacket(0,bWrite,3,5);             // NMRA recommends 5 verify packets
-  loadPacket(0,bWtite,3,6);             // NMRA recommends 6 write or reset packets for decoder recovery time
+  loadPacket(0,bWrite,3,6);             // NMRA recommends 6 write or reset packets for decoder recovery time
       
   c=0;
   d=0;
@@ -349,7 +349,7 @@ void RegisterList::writeCVBit(const char *s) volatile{
   bitClear(bWrite[2],4);              // change instruction code from Write Bit to Verify Bit
   loadPacket(0,resetPacket,2,3);      // NMRA recommends starting with 3 reset packets
   loadPacket(0,bWrite,3,5);           // NMRA recommends 5 verify packets
-  loadPacket(0,bWtite,3,6);           // NMRA recommends 6 write or reset packets for decoder recovery time
+  loadPacket(0,bWrite,3,6);           // NMRA recommends 6 write or reset packets for decoder recovery time
     
   for(int j=0;j<ACK_SAMPLE_COUNT;j++){
     c=(analogRead(CURRENT_MONITOR_PIN_PROG)-base)*ACK_SAMPLE_SMOOTHING+c*(1.0-ACK_SAMPLE_SMOOTHING);

--- a/DCCpp_Uno/src/PacketRegister.cpp
+++ b/DCCpp_Uno/src/PacketRegister.cpp
@@ -221,20 +221,20 @@ void RegisterList::readCV(const char *s) volatile{
     for(int j=0;j<ACK_BASE_COUNT;j++) {
       base+=analogRead(CURRENT_MONITOR_PIN_PROG);
     }
-    base/=ACK_BASE_COUNT;
+  base/=ACK_BASE_COUNT;
 
-    bRead[2]=0xE8+i;
+  bRead[2]=0xE8+i;
 
-loadPacket(0,resetPacket,2,3);            // NMRA recommends starting with 3 reset packets
-loadPacket(0,bRead,3,5);                  // NMRA recommends 5 verify packets
-loadPacket(0, idlePacket, 2, 6);          // NMRA recommends 6 idle or reset packets for decoder recovery time
+  loadPacket(0,resetPacket,2,3);            // NMRA recommends starting with 3 reset packets
+  loadPacket(0,bRead,3,5);                  // NMRA recommends 5 verify packets
+  loadPacket(0, idlePacket, 2, 6);          // NMRA recommends 6 idle or reset packets for decoder recovery time
 
     for(int j=0;j<ACK_SAMPLE_COUNT;j++){
       c=(analogRead(CURRENT_MONITOR_PIN_PROG)-base)*ACK_SAMPLE_SMOOTHING+c*(1.0-ACK_SAMPLE_SMOOTHING);
       if(c>ACK_SAMPLE_THRESHOLD) {
         d=1;
       }
- loadPacket(0,resetPacket,2,1);           // Final reset packet completed (and decoder begins to respond)
+  loadPacket(0,resetPacket,2,1);           // Final reset packet completed (and decoder begins to respond)
     }
 
     bitWrite(bValue,i,d);

--- a/DCCpp_Uno/src/PacketRegister.cpp
+++ b/DCCpp_Uno/src/PacketRegister.cpp
@@ -235,8 +235,7 @@ void RegisterList::readCV(const char *s) volatile{
         d=1;
       }
     }
- loadPacket(0,resetPacket,2,1);           // Final reset packet completed (and decoder begins to respond)
-    bitWrite(bValue,i,d);
+     bitWrite(bValue,i,d);
   }
 
   c=0;
@@ -298,8 +297,6 @@ void RegisterList::writeCVByte(const char *s) volatile{
     base+=analogRead(CURRENT_MONITOR_PIN_PROG);
   base/=ACK_BASE_COUNT;
   
-  loadPacket(0,resetPacket,2,1); // Final reset packet completed (and decoder begins to respond)
-
   bWrite[0]=0x74+(highByte(cv)&0x03);    // set-up to re-verify entire byte
 
   loadPacket(0,resetPacket,2,3);        // NMRA recommends starting with 3 reset packets
@@ -349,8 +346,6 @@ void RegisterList::writeCVBit(const char *s) volatile{
     base+=analogRead(CURRENT_MONITOR_PIN_PROG);
   base/=ACK_BASE_COUNT;
   
-  loadPacket(0,resetPacket,2,1);      // Final reset packet completed (and decoder begins to respond)
-
   bitClear(bWrite[2],4);              // change instruction code from Write Bit to Verify Bit
   loadPacket(0,resetPacket,2,3);      // NMRA recommends starting with 3 reset packets
   loadPacket(0,bWrite,3,5);           // NMRA recommends 5 verify packets


### PR DESCRIPTION
The culprit is the packet sequence that is used to trigger programming, e.g. in RegisterList::readCV in PacketRegister.cpp

loadPacket(0,resetPacket,2,3); // NMRA recommends starting with 3 reset packets
loadPacket(0,bRead,3,5); // NMRA recommends 5 verfy packets
loadPacket(0,resetPacket,2,1); // forces code to wait until all repeats of bRead are completed (and decoder begins to respond)

This is the original code from the BaseStation some decoders do  not perform the acknowledgement because of the last resetPacket that is used to wait until all bRead Packets have been digested. I changed the resetPacket to another bRead Packet and all works fine.

loadPacket(0,resetPacket,2,3); // NMRA recommends starting with 3 reset packets
loadPacket(0,bRead,3,5); // NMRA recommends 5 verify packets
loadPacket(0,bRead,3,1); // forces code to wait until all repeats of bRead are completed (and decoder begins to respond)

Similar changes are made in the routines for WriteCVByte and WriteCVBit.

Fixes https://github.com/DCC-EX/BaseStation/issues/3