### PR TITLE
Update PacketRegister.cpp (#2)

### DIFF
--- a/DCCpp_Uno/src/PacketRegister.cpp
+++ b/DCCpp_Uno/src/PacketRegister.cpp
@@ -207,9 +207,9 @@ void RegisterList::readCV(const char *s) volatile{
   if(sscanf(s,"%d %d %d",&cv,&callBack,&callBackSub) != 3) {         // cv = 1-1024
     return;
   }
-  cv--;                              // actual CV addresses are cv-1 (0-1023)
+  cv--;                                    // actual CV addresses are cv-1 (0-1023)
 
-  bRead[0]=0x78+(highByte(cv)&0x03);   // any CV>1023 will become modulus(1024) due to bit-mask of 0x03
+  bRead[0]=0x78+(highByte(cv)&0x03);       // any CV>1023 will become modulus(1024) due to bit-mask of 0x03
   bRead[1]=lowByte(cv);
 
   bValue=0;
@@ -221,13 +221,13 @@ void RegisterList::readCV(const char *s) volatile{
     for(int j=0;j<ACK_BASE_COUNT;j++) {
       base+=analogRead(CURRENT_MONITOR_PIN_PROG);
     }
-    base/=ACK_BASE_COUNT;
+  base/=ACK_BASE_COUNT;
 
-    bRead[2]=0xE8+i;
+  bRead[2]=0xE8+i;
 
-    loadPacket(0,resetPacket,2,3);          // NMRA recommends starting with 3 reset packets
-    loadPacket(0,bRead,3,5);                // NMRA recommends 5 verfy packets
-    loadPacket(0,resetPacket,2,1);          // forces code to wait until all repeats of bRead are completed (and decoder begins to respond)
+  loadPacket(0,resetPacket,2,3);            // NMRA recommends starting with 3 reset packets
+  loadPacket(0,bRead,3,5);                  // NMRA recommends 5 verify packets
+  loadPacket(0, idlePacket, 2, 6);          // NMRA recommends 6 idle or reset packets for decoder recovery time
 
     for(int j=0;j<ACK_SAMPLE_COUNT;j++){
       c=(analogRead(CURRENT_MONITOR_PIN_PROG)-base)*ACK_SAMPLE_SMOOTHING+c*(1.0-ACK_SAMPLE_SMOOTHING);
@@ -235,8 +235,7 @@ void RegisterList::readCV(const char *s) volatile{
         d=1;
       }
     }
-
-    bitWrite(bValue,i,d);
+     bitWrite(bValue,i,d);
   }
 
   c=0;
@@ -248,19 +247,21 @@ void RegisterList::readCV(const char *s) volatile{
   }
   base/=ACK_BASE_COUNT;
 
-  bRead[0]=0x74+(highByte(cv)&0x03);   // set-up to re-verify entire byte
+  bRead[0]=0x74+(highByte(cv)&0x03);     // set-up to re-verify entire byte
   bRead[2]=bValue;
 
-  loadPacket(0,resetPacket,2,3);          // NMRA recommends starting with 3 reset packets
-  loadPacket(0,bRead,3,5);                // NMRA recommends 5 verfy packets
-  loadPacket(0,resetPacket,2,1);          // forces code to wait until all repeats of bRead are completed (and decoder begins to respond)
-
+  loadPacket(0,resetPacket,2,3);        // NMRA recommends starting with 3 reset packets
+  loadPacket(0,bRead,3,5);              // NMRA recommends 5 verify packets
+  loadPacket(0, idlePacket, 2, 6);      // NMRA recommends 6 idle or reset packets for decoder recovery time
+  
   for(int j=0;j<ACK_SAMPLE_COUNT;j++){
     c=(analogRead(CURRENT_MONITOR_PIN_PROG)-base)*ACK_SAMPLE_SMOOTHING+c*(1.0-ACK_SAMPLE_SMOOTHING);
     if(c>ACK_SAMPLE_THRESHOLD)
       d=1;
   }
-
+  
+  loadPacket(0,resetPacket,2,1);        // Final reset packet completed (and decoder begins to respond)
+  
   if(d==0)    // verify unsuccessful
     bValue=-1;
 
@@ -277,17 +278,17 @@ void RegisterList::writeCVByte(const char *s) volatile{
 
   if(sscanf(s,"%d %d %d %d",&cv,&bValue,&callBack,&callBackSub)!=4)          // cv = 1-1024
     return;
-  cv--;                              // actual CV addresses are cv-1 (0-1023)
+  cv--;                                  // actual CV addresses are cv-1 (0-1023)
 
   bWrite[0]=0x7C+(highByte(cv)&0x03);   // any CV>1023 will become modulus(1024) due to bit-mask of 0x03
   bWrite[1]=lowByte(cv);
   bWrite[2]=bValue;
 
-  loadPacket(0,resetPacket,2,1);
-  loadPacket(0,bWrite,3,4);
-  loadPacket(0,resetPacket,2,1);
-  loadPacket(0,idlePacket,2,10);
-
+ 
+  loadPacket(0,resetPacket,2,3);        // NMRA recommends starting with 3 reset packets
+  loadPacket(0,bWrite,3,5);             // NMRA recommends 5 verify packets
+  loadPacket(0,bWrite,3,6);             // NMRA recommends 6 write or reset packets for decoder recovery time
+    
   c=0;
   d=0;
   base=0;
@@ -295,19 +296,21 @@ void RegisterList::writeCVByte(const char *s) volatile{
   for(int j=0;j<ACK_BASE_COUNT;j++)
     base+=analogRead(CURRENT_MONITOR_PIN_PROG);
   base/=ACK_BASE_COUNT;
-
+  
   bWrite[0]=0x74+(highByte(cv)&0x03);   // set-up to re-verify entire byte
 
-  loadPacket(0,resetPacket,2,3);          // NMRA recommends starting with 3 reset packets
-  loadPacket(0,bWrite,3,5);               // NMRA recommends 5 verfy packets
-  loadPacket(0,resetPacket,2,1);          // forces code to wait until all repeats of bRead are completed (and decoder begins to respond)
-
+  loadPacket(0,resetPacket,2,3);        // NMRA recommends starting with 3 reset packets
+  loadPacket(0,bWrite,3,5);             // NMRA recommends 5 verify packets
+  loadPacket(0,bWrite,3,6);             // NMRA recommends 6 write or reset packets for decoder recovery time
+  
   for(int j=0;j<ACK_SAMPLE_COUNT;j++){
     c=(analogRead(CURRENT_MONITOR_PIN_PROG)-base)*ACK_SAMPLE_SMOOTHING+c*(1.0-ACK_SAMPLE_SMOOTHING);
     if(c>ACK_SAMPLE_THRESHOLD)
       d=1;
   }
-
+  
+  loadPacket(0,resetPacket,2,1);        // Final reset packet (and decoder begins to respond)
+  
   if(d==0)    // verify unsuccessful
     bValue=-1;
 
@@ -324,19 +327,17 @@ void RegisterList::writeCVBit(const char *s) volatile{
 
   if(sscanf(s,"%d %d %d %d %d",&cv,&bNum,&bValue,&callBack,&callBackSub)!=5)          // cv = 1-1024
     return;
-  cv--;                              // actual CV addresses are cv-1 (0-1023)
+  cv--;                                 // actual CV addresses are cv-1 (0-1023)
   bValue=bValue%2;
   bNum=bNum%8;
 
   bWrite[0]=0x78+(highByte(cv)&0x03);   // any CV>1023 will become modulus(1024) due to bit-mask of 0x03
   bWrite[1]=lowByte(cv);
   bWrite[2]=0xF0+bValue*8+bNum;
-
-  loadPacket(0,resetPacket,2,1);
-  loadPacket(0,bWrite,3,4);
-  loadPacket(0,resetPacket,2,1);
-  loadPacket(0,idlePacket,2,10);
-
+  loadPacket(0,resetPacket,2,3);        // NMRA recommends starting with 3 reset packets
+  loadPacket(0,bWrite,3,5);             // NMRA recommends 5 verify packets
+  loadPacket(0,bWrite,3,6);             // NMRA recommends 6 write or reset packets for decoder recovery time
+      
   c=0;
   d=0;
   base=0;
@@ -344,18 +345,19 @@ void RegisterList::writeCVBit(const char *s) volatile{
   for(int j=0;j<ACK_BASE_COUNT;j++)
     base+=analogRead(CURRENT_MONITOR_PIN_PROG);
   base/=ACK_BASE_COUNT;
-
+  
   bitClear(bWrite[2],4);              // change instruction code from Write Bit to Verify Bit
-
-  loadPacket(0,resetPacket,2,3);          // NMRA recommends starting with 3 reset packets
-  loadPacket(0,bWrite,3,5);               // NMRA recommends 5 verfy packets
-  loadPacket(0,resetPacket,2,1);          // forces code to wait until all repeats of bRead are completed (and decoder begins to respond)
-
+  loadPacket(0,resetPacket,2,3);      // NMRA recommends starting with 3 reset packets
+  loadPacket(0,bWrite,3,5);           // NMRA recommends 5 verify packets
+  loadPacket(0,bWrite,3,6);           // NMRA recommends 6 write or reset packets for decoder recovery time
+    
   for(int j=0;j<ACK_SAMPLE_COUNT;j++){
     c=(analogRead(CURRENT_MONITOR_PIN_PROG)-base)*ACK_SAMPLE_SMOOTHING+c*(1.0-ACK_SAMPLE_SMOOTHING);
     if(c>ACK_SAMPLE_THRESHOLD)
       d=1;
   }
+  
+  loadPacket(0,resetPacket,2,1);      // Final reset packetcompleted (and decoder begins to respond)
 
   if(d==0)    // verify unsuccessful
     bValue=-1;


### PR DESCRIPTION
* Update PacketRegister.cpp

The culprit is the packet sequence that is used to trigger programming, e.g. in RegisterList::readCV in PacketRegister.cpp

loadPacket(0,resetPacket,2,3); // NMRA recommends starting with 3 reset packets
loadPacket(0,bRead,3,5); // NMRA recommends 5 verfy packets
loadPacket(0,resetPacket,2,1); // forces code to wait until all repeats of bRead are completed (and decoder begins to respond)

This is the original code from the BaseStation. The DH10C does not perform the acknowledgement because of the last resetPacket that is used to wait until all bRead Packets have been digested. I changed the resetPacket to another bRead Packet and all works fine.

loadPacket(0,resetPacket,2,3); // NMRA recommends starting with 3 reset packets
loadPacket(0,bRead,3,5); // NMRA recommends 5 verify packets
loadPacket(0,bRead,3,1); // forces code to wait until all repeats of bRead are completed (and decoder begins to respond)

Similar changes are made in the routines for WriteCVByte and WriteCVBit.

* Update PacketRegister.cpp

* Update PacketRegister.cpp

* Update PacketRegister.cpp

* Update PacketRegister.cpp

* Update PacketRegister.cpp

* Update PacketRegister.cpp

Fix typos bWrite was spelled bWtite

Co-authored-by: FrightRisk <37218136+FrightRisk@users.noreply.github.com>