### PR TITLE
Correct mentions of SHOW_CONFIG_PIN

### DIFF
--- a/DCCpp_EX/DCCppEX/Config.h
+++ b/DCCpp_EX/DCCppEX/Config.h
@@ -90,7 +90,7 @@ Part of DCC++ BASE STATION for the Arduino
 // DEFINE PIN THAT WILL BE TIED TO GROUND TO DISPLAY DETAILED CONFIGURATION INFORMATION
 //
 // Note: With the Arduino power disconnected, place a jumper between this pin and ground.
-//       When the Arduino is rebooted, detailed infomration will be displayed on the 
+//       When the Arduino is rebooted, detailed information will be displayed on the 
 //       serial connection and the Arduino will halt. Remove the jumper and reboot for
 //       normal operation
 

--- a/DCCpp_EX/DCCppEX/Config.h
+++ b/DCCpp_EX/DCCppEX/Config.h
@@ -87,6 +87,17 @@ Part of DCC++ BASE STATION for the Arduino
 
 /////////////////////////////////////////////////////////////////////////////////////
 //
+// DEFINE PIN THAT WILL BE TIED TO GROUND TO DISPLAY DETAILED CONFIGURATION INFORMATION
+//
+// Note: With the Arduino power disconnected, place a jumper between this pin and ground.
+//       When the Arduino is rebooted, detailed infomration will be displayed on the 
+//       serial connection and the Arduino will halt. Remove the jumper and reboot for
+//       normal operation
+
+#define SHOW_CONFIG_PIN A5
+
+/////////////////////////////////////////////////////////////////////////////////////
+//
 // DEFINE LCD SCREEN USAGE BY THE BASE STATION
 //
 // Note: This feature requires an I2C enabled LCD screen using a PCF8574 based chipset.

--- a/DCCpp_EX/DCCppEX/DCCppEX.ino
+++ b/DCCpp_EX/DCCppEX/DCCppEX.ino
@@ -264,9 +264,9 @@ void setup(){
 
   EEStore::init();                                         // initialize and load Turnout and Sensor definitions stored in EEPROM
 
-  pinMode(A5,INPUT);                                       // if pin A5 is grounded upon start-up, print system configuration and halt
-  digitalWrite(A5,HIGH);
-  if(!digitalRead(A5))
+  pinMode(SHOW_CONFIG_PIN,INPUT);                                       // if pin SHOW_CONFIG_PIN is grounded upon start-up, print system configuration and halt
+  digitalWrite(SHOW_CONFIG_PIN,HIGH);
+  if(!digitalRead(SHOW_CONFIG_PIN))
     showConfiguration();
 
   CommManager::printf("<iDCC++ BASE STATION FOR ARDUINO %s / %s: V-%s / %s %s>", ARDUINO_TYPE, MOTOR_SHIELD_NAME, VERSION, __DATE__, __TIME__);
@@ -482,7 +482,7 @@ ISR(TIMER3_COMPB_vect){              // set interrupt service for OCR3B of TIMER
 
 ///////////////////////////////////////////////////////////////////////////////
 // PRINT CONFIGURATION INFO TO SERIAL PORT REGARDLESS OF INTERFACE TYPE
-// - ACTIVATED ON STARTUP IF SHOW_CONFIG_PIN IS TIED HIGH
+// - ACTIVATED ON STARTUP IF SHOW_CONFIG_PIN IS TIED TO GROUND
 
 void showConfiguration(){
   Serial.print("\n*** DCC++ CONFIGURATION ***\n");


### PR DESCRIPTION
the SHOW_CONFIG_PIN constant was mentioned, but not used. Pin A5 was hard coded as the pin that needed to be used to show detailed configuration information at boot. Also, the comments incorrectly said that the pin needed to be connected HIGH. The pin needs to be connected to LOW (ground) for this to work.